### PR TITLE
fix: config overwritten by default one

### DIFF
--- a/src/option.js
+++ b/src/option.js
@@ -5,8 +5,8 @@ const _ = require('lodash');
 
 function getOptions(from) {
     const opts = _.mergeWith(
-        from || {},
         DEFAULT_OPTIONS,
+        from || {},
         // concat array instead of recursive merge
         (objVal, srcVal) => {
             if (_.isArray(objVal)) {


### PR DESCRIPTION
This commit swap `srcObj` and `targetObj` in `_.mergeWith`, so that user-specified config will overwrite the default ones, instead of vice versa.